### PR TITLE
Add dynamic donut charts for project Lighthouse scores

### DIFF
--- a/wp-content/themes/porta/components/c-metrics-donut.php
+++ b/wp-content/themes/porta/components/c-metrics-donut.php
@@ -1,0 +1,80 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$post_id = get_the_ID();
+
+$metrics_map = [
+    'performance'     => [
+        'meta_key' => 'performance_score',
+        'label'    => __( 'Rendimiento', 'porta' ),
+        'color'    => '#f28b20',
+    ],
+    'accessibility'   => [
+        'meta_key' => 'accessibility_score',
+        'label'    => __( 'Accesibilidad', 'porta' ),
+        'color'    => '#f28b20',
+    ],
+    'best-practices'  => [
+        'meta_key' => 'best_practices_score',
+        'label'    => __( 'Recomendaciones', 'porta' ),
+        'color'    => '#2ca24c',
+    ],
+    'seo'             => [
+        'meta_key' => 'seo_score',
+        'label'    => __( 'SEO', 'porta' ),
+        'color'    => '#f28b20',
+    ],
+];
+
+$metrics_to_render = [];
+
+foreach ( $metrics_map as $metric_id => $metric_data ) {
+    $raw_score = get_post_meta( $post_id, $metric_data['meta_key'], true );
+
+    if ( $raw_score === '' ) {
+        continue;
+    }
+
+    $score = (int) $raw_score;
+    $score = max( 0, min( 100, $score ) );
+
+    $metrics_to_render[] = [
+        'id'    => $metric_id,
+        'label' => $metric_data['label'],
+        'score' => $score,
+        'color' => $metric_data['color'],
+    ];
+}
+
+if ( empty( $metrics_to_render ) ) {
+    return;
+}
+?>
+
+<section class="layout-metrics layout-metrics--donut" aria-labelledby="project-metrics-title" data-aos="fade-up">
+    <header class="metrics-donut__header">
+        <p class="section-label"><?php esc_html_e( 'Auditoría', 'porta' ); ?></p>
+        <h2 id="project-metrics-title" class="metrics-donut__title"><?php esc_html_e( 'Resultados Lighthouse', 'porta' ); ?></h2>
+        <p class="metrics-donut__description">
+            <?php esc_html_e( 'Valores obtenidos en las pruebas de rendimiento, accesibilidad, buenas prácticas y SEO.', 'porta' ); ?>
+        </p>
+    </header>
+
+    <div class="metrics-donut__grid" role="list">
+        <?php foreach ( $metrics_to_render as $metric ) : ?>
+            <article
+                class="metrics-donut__item"
+                role="listitem"
+                aria-label="<?php echo esc_attr( sprintf( __( '%s: %d/100', 'porta' ), $metric['label'], $metric['score'] ) ); ?>"
+            >
+                <div class="metrics-donut__chart" data-score="<?php echo esc_attr( $metric['score'] ); ?>" data-color="<?php echo esc_attr( $metric['color'] ); ?>">
+                    <canvas class="js-metric-chart" aria-hidden="true"></canvas>
+                    <span class="metrics-donut__value" aria-live="polite"><?php echo esc_html( $metric['score'] ); ?></span>
+                </div>
+                <p class="metrics-donut__label"><?php echo esc_html( $metric['label'] ); ?></p>
+            </article>
+        <?php endforeach; ?>
+    </div>
+</section>

--- a/wp-content/themes/porta/functions.php
+++ b/wp-content/themes/porta/functions.php
@@ -13,6 +13,30 @@ add_theme_support( 'post-formats', array(
   'chat',
 ) );
 
+add_action( 'wp_enqueue_scripts', 'porta_enqueue_theme_assets' );
+
+function porta_enqueue_theme_assets() {
+  if ( ! is_singular() ) {
+    return;
+  }
+
+  wp_enqueue_script(
+    'porta-chartjs',
+    'https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js',
+    array(),
+    '4.4.1',
+    true
+  );
+
+  wp_enqueue_script(
+    'porta-metrics-charts',
+    get_template_directory_uri() . '/scripts/metrics-charts.js',
+    array( 'porta-chartjs' ),
+    filemtime( get_template_directory() . '/scripts/metrics-charts.js' ),
+    true
+  );
+}
+
 // Registro de post
 add_action('init', 'Web');
 function Web() {

--- a/wp-content/themes/porta/scripts/metrics-charts.js
+++ b/wp-content/themes/porta/scripts/metrics-charts.js
@@ -1,0 +1,67 @@
+(function () {
+  function initialiseMetricCharts() {
+    if (typeof Chart === 'undefined') {
+      return;
+    }
+
+    var chartContainers = document.querySelectorAll('.metrics-donut__chart');
+
+    Array.prototype.forEach.call(chartContainers, function (container) {
+      var canvas = container.querySelector('.js-metric-chart');
+      if (!canvas) {
+        return;
+      }
+
+      var score = parseFloat(container.getAttribute('data-score'));
+      if (!isFinite(score)) {
+        return;
+      }
+
+      var color = container.getAttribute('data-color') || '#f28b20';
+      var context = canvas.getContext('2d');
+
+      new Chart(context, {
+        type: 'doughnut',
+        data: {
+          labels: ['Score', 'Rest'],
+          datasets: [
+            {
+              data: [score, Math.max(0, 100 - score)],
+              backgroundColor: [color, '#f0f0f0'],
+              borderWidth: 0,
+              hoverOffset: 4,
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          cutout: '78%',
+          plugins: {
+            legend: {
+              display: false,
+            },
+            tooltip: {
+              callbacks: {
+                label: function (context) {
+                  if (context.dataIndex === 0) {
+                    return context.parsed + '/100';
+                  }
+
+                  return null;
+                },
+              },
+              displayColors: false,
+            },
+          },
+        },
+      });
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initialiseMetricCharts);
+  } else {
+    initialiseMetricCharts();
+  }
+})();

--- a/wp-content/themes/porta/single.php
+++ b/wp-content/themes/porta/single.php
@@ -95,6 +95,10 @@ include('header.php');
             <?php endif; ?>
     </section>
 
+    <?php
+        include('components/c-metrics-donut.php');
+    ?>
+
     <?php 
         // CONTENIDO RELACIONADO
         include('components/c-related.php'); 

--- a/wp-content/themes/porta/style.css
+++ b/wp-content/themes/porta/style.css
@@ -181,6 +181,87 @@ a.btn--dark:hover{
   gap: var(--spacing-lg);
 }
 
+.layout-metrics--donut {
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.metrics-donut__header {
+  max-width: 32rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.metrics-donut__title {
+  font-size: var(--font-size-md);
+}
+
+.metrics-donut__description {
+  color: #555;
+  font-size: 1rem;
+}
+
+.metrics-donut__grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--spacing-lg);
+}
+
+.metrics-donut__item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-sm);
+  text-align: center;
+}
+
+.metrics-donut__chart {
+  position: relative;
+  width: 140px;
+  aspect-ratio: 1 / 1;
+}
+
+.metrics-donut__chart canvas {
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.metrics-donut__value {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-family: var(--font-title);
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+}
+
+.metrics-donut__label {
+  font-weight: 600;
+}
+
+@media (max-width: 1024px) {
+  .metrics-donut__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 600px) {
+  .layout-metrics--donut {
+    padding: var(--spacing-md) var(--spacing-sm);
+  }
+
+  .metrics-donut__grid {
+    grid-template-columns: 1fr;
+    gap: var(--spacing-md);
+  }
+
+  .metrics-donut__chart {
+    width: 120px;
+  }
+}
+
 .layout-footer {
 padding:  var(--spacing-md);
  background-color: var(--color-text);

--- a/wp-content/themes/porta/styles/base.css
+++ b/wp-content/themes/porta/styles/base.css
@@ -180,6 +180,87 @@ a.btn--dark:hover{
   gap: var(--spacing-lg);
 }
 
+.layout-metrics--donut {
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.metrics-donut__header {
+  max-width: 32rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.metrics-donut__title {
+  font-size: var(--font-size-md);
+}
+
+.metrics-donut__description {
+  color: #555;
+  font-size: 1rem;
+}
+
+.metrics-donut__grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--spacing-lg);
+}
+
+.metrics-donut__item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-sm);
+  text-align: center;
+}
+
+.metrics-donut__chart {
+  position: relative;
+  width: 140px;
+  aspect-ratio: 1 / 1;
+}
+
+.metrics-donut__chart canvas {
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.metrics-donut__value {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-family: var(--font-title);
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+}
+
+.metrics-donut__label {
+  font-weight: 600;
+}
+
+@media (max-width: 1024px) {
+  .metrics-donut__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 600px) {
+  .layout-metrics--donut {
+    padding: var(--spacing-md) var(--spacing-sm);
+  }
+
+  .metrics-donut__grid {
+    grid-template-columns: 1fr;
+    gap: var(--spacing-md);
+  }
+
+  .metrics-donut__chart {
+    width: 120px;
+  }
+}
+
 .layout-footer {
 padding:  var(--spacing-md);
  background-color: var(--color-text);


### PR DESCRIPTION
## Summary
- add a reusable metrics component that renders Lighthouse-inspired donut charts on project pages
- enqueue Chart.js alongside a tailored script to hydrate the donut charts
- extend theme styles to support the new metrics layout across breakpoints

## Testing
- php -l wp-content/themes/porta/components/c-metrics-donut.php
- php -l wp-content/themes/porta/functions.php
- php -l wp-content/themes/porta/single.php

------
https://chatgpt.com/codex/tasks/task_e_68e4334ae0e0832badbcb53a479197cd